### PR TITLE
Restore original margin and min-height in roadmapEvent

### DIFF
--- a/src/pages/event/Event.module.css
+++ b/src/pages/event/Event.module.css
@@ -331,9 +331,9 @@
   position: relative;
   display: flex;
   align-items: center;
-  margin-bottom: 1.5rem; /* Reduced from 3rem to 1.5rem */
+  margin-bottom: 3rem;
   animation: slideInCenter 0.8s ease-out both;
-  min-height: 150px; /* Reduced from 200px to 150px */
+  min-height: 200px;
 }
 
 .roadmapEvent:nth-child(even) {


### PR DESCRIPTION
Reverts previous reductions to margin-bottom and min-height for the .roadmapEvent class, restoring them to 3rem and 200px respectively for improved spacing and layout consistency.