### PR TITLE
Update hero section text and button link

### DIFF
--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -103,11 +103,11 @@ const Home = () => {
               Experience the Thrilling AUST CSE Carnival
             </h1>
             <p className={styles.heroSubtitle}>
-              Join us for a day of innovation, competition, and fun!
+              Join us for a week of innovation, competition, and fun!
             </p>
             <div className={styles.heroButtons}>
               <Link to="/event" className={styles.btnPrimary}>Learn More</Link>
-              <Link to="/contact" className={styles.btnSecondary}>Register Now</Link>
+              <Link to="Join us for a week of innovation, competition, and fun!" className={styles.btnSecondary}>Facebook Page</Link>
             </div>
           </div>
 


### PR DESCRIPTION
Changed the event duration in the hero subtitle from 'day' to 'week' and updated the secondary button to link to the Facebook page instead of the contact page.